### PR TITLE
Fixed typo in copyright in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,7 +98,7 @@ const config = {
           Apache Polaris is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
         </p>
         <p>
-          Copyyright © 2024 The Apache Software Foundation, Licensed under the Apache License, Version 2.0. <br/>
+          Copyright © 2024 The Apache Software Foundation, Licensed under the Apache License, Version 2.0. <br/>
           Apache Polaris, the names of other Apache projects, and the ASF logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.
         </p>
         </div>`,


### PR DESCRIPTION
Fixes typo in Copyright at the footer. Refer issue https://github.com/apache/polaris/issues/275 for details.

Tested by building and running the site locally
